### PR TITLE
Spoon Collector - Fix codebase import via Github not working

### DIFF
--- a/collectors/spoon-callgraph/src/main/java/SpoonCallGraph.java
+++ b/collectors/spoon-callgraph/src/main/java/SpoonCallGraph.java
@@ -57,11 +57,11 @@ public class SpoonCallGraph {
             System.out.println("Cloning repository...");
             // clone repo to tmp folder
             Git.cloneRepository()
-                    .setURI(repoURL)
+                    .setURI(sourcesPath)
                     .setDirectory(file)
                     .call();
 
-            String[] split = repoURL.split("/");
+            String[] split = sourcesPath.split("/");
             String[] split1 = split[split.length - 1].split("\\.");
             projectName = split1[0];
         }

--- a/collectors/spoon-callgraph/src/main/java/SpoonCallGraph.java
+++ b/collectors/spoon-callgraph/src/main/java/SpoonCallGraph.java
@@ -18,7 +18,6 @@ public class SpoonCallGraph {
     private static int ormChoice = -1;
 
     private static String sourcesPath = null;
-    private static String repoURL = null;
     private static String projectNameInput = null;
 
     public static void main(String[] args) throws GitAPIException, IOException {

--- a/collectors/spoon-callgraph/src/main/java/SpoonCallGraph.java
+++ b/collectors/spoon-callgraph/src/main/java/SpoonCallGraph.java
@@ -85,6 +85,7 @@ public class SpoonCallGraph {
             String input = scanner.nextLine();
             if (input.equals("YES"))
                 FileUtils.deleteDirectory(file);
+            scanner.close();
         }
     }
 

--- a/collectors/spoon-callgraph/src/main/java/SpoonCallGraph.java
+++ b/collectors/spoon-callgraph/src/main/java/SpoonCallGraph.java
@@ -100,8 +100,10 @@ public class SpoonCallGraph {
         JTextField projectNameField = new JTextField(5);
         JTextField pathField = new JTextField(5);
 
-        panel.add(new JLabel("Project name:"));
-        panel.add(projectNameField);
+        if (sourcesChoice != Constants.GITHUB) {
+            panel.add(new JLabel("Project name:"));
+            panel.add(projectNameField);
+        }
 
         String sourcesText = "";
         if (sourcesChoice == Constants.LOCAL && launcherChoice != Constants.JAR_LAUNCHER)


### PR DESCRIPTION
**Description:**
The Spoon Collector has an option that allows to import a codebase via its Github repository link. The option is currently not working and results in a crash.

This was caused by the `repoUrl` variable never being set to the repo url, being instead stored `sourcesPath`.

**Solution:**
- Eliminated the `repoUrl` variable, the folder path and url of the codebase now both use the `sourcesPath` variable
- Removed the project name input field when importing via Github, because it is always ignored and set to the name of the repository

**Known issues:**
None