### PR TITLE
fix: The creation of a collection of entities is considered a write access in spoon-collector

### DIFF
--- a/collectors/spoon-callgraph/src/main/java/collectors/JPA/SpringDataJPACollector.java
+++ b/collectors/spoon-callgraph/src/main/java/collectors/JPA/SpringDataJPACollector.java
@@ -435,14 +435,6 @@ public class SpringDataJPACollector extends SpoonCollector {
         String createdTypeName = ctConstructorCall.getExecutable().getType().getSimpleName();
         if (allDomainEntities.contains(createdTypeName)) {
             addEntitiesSequenceAccess(createdTypeName, "W");
-        } else {
-            // Might be a collection (List<Entity>, Map<String, Entity>, ...)
-            for (CtTypeReference<?> typeArguments : ctConstructorCall.getType().getActualTypeArguments()) {
-                if (allDomainEntities.contains(typeArguments.getSimpleName())) {
-                    addEntitiesSequenceAccess(typeArguments.getSimpleName(), "W");
-                    break;
-                }
-            }
         }
     }
 


### PR DESCRIPTION
In the spoon-collector, the creation of a parameterised type, like a collection, whose parameter is an entity is considered a write access ("W") to the entity.