### PR TITLE
🔨 Fix line endings in compile.sh script for compatibility

### DIFF
--- a/tools/functionality_refactor/src/Dockerfile
+++ b/tools/functionality_refactor/src/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y ca-certificates
 COPY . /app
 
 WORKDIR /app
+RUN sed -i 's/\r$//' /app/scripts/compile.sh
 
 RUN make build
 


### PR DESCRIPTION
In order for the `docker-compose` deployment pipeline to run properly in a Windows build environment, the line endings in shell scripts must be normalized to LF. 